### PR TITLE
Fixes error where app module fails to load in testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: node_js
 node_js: ["0.10"]
+before_install:
+  - export CHROME_BIN=chromium-browser
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
 before_script:
   - npm install -g bower gulp
   - bower install

--- a/dist/angular-zendesk-widget.js
+++ b/dist/angular-zendesk-widget.js
@@ -10,13 +10,12 @@
         }
 
         var window = $window;
+
         // Following is essentially a copy paste of JS portion of the Zendesk embed code
         // with our settings subbed in. For more info, see:
         // https://support.zendesk.com/hc/en-us/articles/203908456-Using-Web-Widget-to-embed-customer-service-in-your-website
 
-        // Note that JSHint ignore is not working in latest release, so can't actually turn
-        // on JSHint yet. See https://github.com/jshint/jshint/issues/2411
-        /* jshint ignore:start */
+        /*eslint-disable */
 
         window.zEmbed || function(e, t) {
           var n, o, d, i, s, a = [],
@@ -35,7 +34,7 @@
           }, o.write('<body onload="document._l();">'), o.close()
         }("https://assets.zendesk.com/embeddable_framework/main.js", zendeskWidgetSettings.accountUrl);
 
-        /* jshint ignore:end */
+        /*eslint-enable */
 
         $window.zE(function() {
           zendeskWidgetSettings.beforePageLoad($window.zE);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -72,7 +72,8 @@ gulp.task('lint', function () {
         module: true,
         require: true,
         __dirname: true,
-        document: true
+        document: true,
+        process: true
       }
     }))
     // Outputs the results to the console

--- a/karma-dist-concatenated.conf.js
+++ b/karma-dist-concatenated.conf.js
@@ -17,7 +17,6 @@ module.exports = function(config) {
       'karma-chai',
       'karma-sinon-chai',
       'karma-chrome-launcher',
-      'karma-phantomjs-launcher',
       'karma-jquery',
       'karma-chai-jquery'
     ],
@@ -67,11 +66,25 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['PhantomJS'],
+    browsers: ['Chrome'],
+
+
+    // Use a custom launcher to run Chrome on TravisCI
+    customLaunchers: {
+      Chrome_travis_ci: {
+        base: 'Chrome',
+        flags: ['--no-sandbox']
+      }
+    },
 
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
     singleRun: false
   });
+
+  // Switch browser to Chrome if TravisCI is detected
+  if (process.env.TRAVIS) {
+    config.browsers = ['Chrome_travis_ci'];
+  }
 };

--- a/karma-dist-concatenated.conf.js
+++ b/karma-dist-concatenated.conf.js
@@ -10,15 +10,13 @@ module.exports = function(config) {
 
     // frameworks to use
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-    frameworks: ['mocha', 'chai-jquery', 'jquery-1.8.3', 'sinon-chai'],
+    frameworks: ['jasmine'],
 
     plugins: [
-      'karma-mocha',
-      'karma-chai',
+      'karma-jasmine',
       'karma-sinon-chai',
       'karma-chrome-launcher',
-      'karma-jquery',
-      'karma-chai-jquery'
+      'karma-spec-reporter'
     ],
 
     // list of files / patterns to load in the browser

--- a/karma-dist-minified.conf.js
+++ b/karma-dist-minified.conf.js
@@ -10,15 +10,13 @@ module.exports = function(config) {
 
     // frameworks to use
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-    frameworks: ['mocha', 'chai-jquery', 'jquery-1.8.3', 'sinon-chai'],
+    frameworks: ['jasmine'],
 
     plugins: [
-      'karma-mocha',
-      'karma-chai',
+      'karma-jasmine',
       'karma-sinon-chai',
       'karma-chrome-launcher',
-      'karma-jquery',
-      'karma-chai-jquery'
+      'karma-spec-reporter'
     ],
 
     // list of files / patterns to load in the browser

--- a/karma-dist-minified.conf.js
+++ b/karma-dist-minified.conf.js
@@ -17,7 +17,6 @@ module.exports = function(config) {
       'karma-chai',
       'karma-sinon-chai',
       'karma-chrome-launcher',
-      'karma-phantomjs-launcher',
       'karma-jquery',
       'karma-chai-jquery'
     ],
@@ -67,11 +66,24 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['PhantomJS'],
+    browsers: ['Chrome'],
 
+
+    // Use a custom launcher to run Chrome on TravisCI
+    customLaunchers: {
+      Chrome_travis_ci: {
+        base: 'Chrome',
+        flags: ['--no-sandbox']
+      }
+    },
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
     singleRun: false
   });
+
+  // Switch browser to Chrome if TravisCI is detected
+  if (process.env.TRAVIS) {
+    config.browsers = ['Chrome_travis_ci'];
+  }
 };

--- a/karma-src.conf.js
+++ b/karma-src.conf.js
@@ -15,7 +15,7 @@ module.exports = function(config) {
     plugins: [
       'karma-jasmine',
       'karma-sinon-chai',
-      'karma-phantomjs-launcher',
+      'karma-chrome-launcher',
       'karma-spec-reporter'
     ],
 
@@ -65,11 +65,26 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['PhantomJS'],
+    browsers: ['Chrome'],
+
+
+    // Use a custom launcher to run Chrome on TravisCI
+    customLaunchers: {
+      Chrome_travis_ci: {
+        base: 'Chrome',
+        flags: ['--no-sandbox']
+      }
+    },
 
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
     singleRun: false
   });
+
+  // Switch browser to Chrome if TravisCI is detected
+  if (process.env.TRAVIS) {
+    config.browsers = ['Chrome_travis_ci'];
+  }
 };
+

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "karma-jasmine": "^0.3.6",
     "karma-jquery": "^0.1.0",
     "karma-mocha": "^0.1.8",
-    "karma-phantomjs-launcher": "^0.1.4",
     "karma-sinon-chai": "^0.2.0",
     "karma-spec-reporter": "^0.0.18",
     "mocha": "^1.21.4",

--- a/package.json
+++ b/package.json
@@ -29,10 +29,8 @@
     "karma-chrome-launcher": "^0.1.4",
     "karma-jasmine": "^0.3.6",
     "karma-jquery": "^0.1.0",
-    "karma-mocha": "^0.1.8",
     "karma-sinon-chai": "^0.2.0",
     "karma-spec-reporter": "^0.0.18",
-    "mocha": "^1.21.4",
     "run-sequence": "^1.0.2",
     "sinon": "^1.10.3",
     "sinon-chai": "^2.5.0"

--- a/test/unit/angular-zendesk-widget/zendeskWidgetSpec.js
+++ b/test/unit/angular-zendesk-widget/zendeskWidgetSpec.js
@@ -8,7 +8,7 @@ describe('Angular Zendesk Widget', function() {
       module('zendeskWidget');
       expect(function() {
         inject()
-      }).toThrow();
+      }).toThrowError('Missing accountUrl. Please set in app config via ZendeskWidgetProvider');
     });
 
   });


### PR DESCRIPTION
# Summary
- Fixes a known compatibility issue where the app module fails to load in the testing environment (5fa13245cc536af723a464cb02bc9b2d54ea5b80, https://github.com/angular/angular.js/issues/13794)
- Fixes an existing test to be more robust: previously, the assertion would pass on _every_ error which is undesirable. [[LOC](https://github.com/CrossLead/angular-zendesk-widget/pull/4/commits/5fa13245cc536af723a464cb02bc9b2d54ea5b80#diff-1d1c767b303c6751bae1b1c77086c713R11)]
- Because Karma doesn't officially support PhantomJS, this PR removes its support in favor of Chrome (5ad766407e53ac6ae64f6b8e65661f1727af45cf) If you strongly prefer PhantomJS, we can alternatively fix the issue by upgrading to PhantomJS 2.x. [[Review](https://github.com/CrossLead/angular-zendesk-widget/commit/1162b724ddaccbb181a25298d40dc91f8990fbba)]. I'll leave it to you to decide.
## Tasks
- [x] Comment below if you prefer upgrading PhantomJS
- [x] If this PR is merged, delete the alternative branch: `git push origin --delete  fixes_ng_module_error_phantomjs_upgrade`
## Testing
- [x] Run `./node_modules/.bin/gulp test-src`. Is the test passing?
- [x] Change the [assertion message](https://github.com/CrossLead/angular-zendesk-widget/pull/4/files#diff-1d1c767b303c6751bae1b1c77086c713R11) to purposely fail the test , run the test, and observe that it fails with the correct feedback
